### PR TITLE
Correct REPR_SHAVE_BITS and MODULUS_BITS in Fr

### DIFF
--- a/starknet-curve/src/fields/fr.rs
+++ b/starknet-curve/src/fields/fr.rs
@@ -80,11 +80,11 @@ impl FpParameters for FrParameters {
         0x07fffffffffff9b1,
     ]);
 
-    const MODULUS_BITS: u32 = 251;
+    const MODULUS_BITS: u32 = 252;
 
     const CAPACITY: u32 = Self::MODULUS_BITS - 1;
 
-    const REPR_SHAVE_BITS: u32 = 5;
+    const REPR_SHAVE_BITS: u32 = 4;
 
     // INV = -q^{-1} (mod 2^64)
     const INV: u64 = 13504954208620504625;


### PR DESCRIPTION
Using https://github.com/geometryresearch/field_params_generator, we see that `MODULUS_BITS` should be 252 and `REPR_SHAVE_BITS` should be 4. This is discussed in our #vuf channel.

```bash
$ sage run.sage 3618502788666131213697322783095070105526743751716087489154079457884512865583 
MODULUS: 3618502788666131213697322783095070105526743751716087489154079457884512865583
0x1e66a241adc64d2f, 0xb781126dcae7b232, 0xffffffffffffffff, 0x0800000000000010,

MODULUS_BITS: 252

CAPACITY: 251

REPR_SHAVE_BITS: 4

R: 3618502788666127798953978732740734581940928362441851875681120813493230806863
0x51925a0bf4fca74f, 0xc75ec4b46df16bee, 0x0000000000000008, 0x07fffffffffffdf1,

R2: 3551179599793676589179020395559770927735842444383898408469482222901708744845
0x6021b3f1ea1c688d, 0x509cf64d14ce60b9, 0xbaf0ab4cf78bbabb, 0x07d9e57c2333766e,

MODULUS_MINUS_ONE_DIV_TWO: 1809251394333065606848661391547535052763371875858043744577039728942256432791
0x0f335120d6e32697, 0xdbc08936e573d919, 0x7fffffffffffffff, 0x0400000000000008,

GENERATOR: 3618502788666120969467290632032063534769297583893380648735203524710666689423
0xb7e9c9a083695b8f, 0xe71a2941b404df66, 0x000000000000001a, 0x07fffffffffff9b1,

INV: 13504954208620504625

T: 1809251394333065606848661391547535052763371875858043744577039728942256432791
0x0f335120d6e32697, 0xdbc08936e573d919, 0x7fffffffffffffff, 0x0400000000000008,

T_MINUS_ONE_DIV_TWO: 904625697166532803424330695773767526381685937929021872288519864471128216395
0x8799a8906b71934b, 0xede0449b72b9ec8c, 0x3fffffffffffffff, 0x0200000000000004,

TWO_ADICITY: 1

TWO_ADIC_ROOT_OF_UNITY: 3414743344050354335523585815389274235613472958644391282058720
0xccd44835b8c9a5e0, 0xf0224db95cf64643, 0xfffffffffffffff6, 0x000000000000021f,
```